### PR TITLE
fixed header width

### DIFF
--- a/src/layout/Dashboard/Header/AppBarStyled.jsx
+++ b/src/layout/Dashboard/Header/AppBarStyled.jsx
@@ -17,7 +17,7 @@ const AppBarStyled = styled(AppBar, { shouldForwardProp: (prop) => prop !== 'ope
     duration: theme.transitions.duration.leavingScreen
   }),
   ...(!open && {
-    width: `calc(100% - ${theme.spacing(7.5)})`
+    width: `calc(100%)`
   }),
   ...(open && {
     marginLeft: drawerWidth,


### PR DESCRIPTION
The navigation bar of the close menu is not the right width

![image](https://github.com/codedthemes/mantis-free-react-admin-template/assets/82922648/49161cb3-3b0f-49eb-808a-cbb9919abd4a)
